### PR TITLE
Add molecule and ansatz for metrics table

### DIFF
--- a/module/hackathon.20181006/module.py
+++ b/module/hackathon.20181006/module.py
@@ -31,7 +31,7 @@ selector2=[
     {'name':'Minimizer', 'key':'_minimizer_method'},
     {"name":"Ansatz", "key":"_ansatz_method"},
     {"name":"Point", "key":"_point"},
-    {'name':'Molecule', 'key':'molecule', 'filter_by_all':False },
+    {'name':'Molecule', 'key':'_molecule', 'filter_by_all':False },
 ]
 
 selector3=[
@@ -211,6 +211,7 @@ def get_raw_data(i):
                     {
                         # features
                         'platform': characteristics['run'].get('vqe_input', {}).get('q_device_name', 'unknown').lower(),
+                        'molecule': molecule,
                         # choices
                         'minimizer_method': characteristics['run'].get('vqe_input', {}).get('minimizer_method', 'n/a'),
                         'minimizer_options': characteristics['run'].get('vqe_input', {}).get('minimizer_options', {'maxfev':-1}),
@@ -231,7 +232,7 @@ def get_raw_data(i):
                 ]
                 
                 index = [
-                    'platform', 'team', 'minimizer_method', 'sample_number', 'max_iterations', 'point', 'repetition_id'
+                    'platform', 'team', 'minimizer_method', 'sample_number', 'max_iterations', 'point', 'repetition_id', 'molecule'
                 ]
 
                 for datum in data:
@@ -247,7 +248,6 @@ def get_raw_data(i):
                     datum['total_q_seconds'] = np.float64(datum.get('report',{}).get('total_q_seconds',0))
                     datum['total_q_shots'] = np.int64(datum.get('report',{}).get('total_q_shots',0))
                     datum['max_iterations'] = np.int64(datum.get('max_iterations',-1))
-                    datum['molecule'] = molecule
                     datum['vendor'] = vendor
                     for key in index:
                         datum['_' + key] = datum[key]
@@ -279,8 +279,8 @@ def get_raw_data(i):
             df_curr = pd.DataFrame(row).T
             # Check if this row is similar to the previous row.
             if df_prev is not None: # if not the very first row
-                if df_prev.index.levels[:-2]==df_curr.index.levels[:-2]: # if the indices match for all but the last two levels
-                    if df_prev.index.levels[-2]!=df_curr.index.levels[-2]: # if the experiments are different
+                if df_prev.index.levels[:5]==df_curr.index.levels[:5]: # if the indices match for all but the last two levels
+                    if df_prev.index.levels[5]!=df_curr.index.levels[5]: # if the experiments are different
                         if df_prev['minimizer_src'].values==df_curr['minimizer_src'].values and df_prev['ansatz_src'].values==df_curr['ansatz_src'].values: # if the minimizer and ansatz sources are the same
                             print('[Info] Merging experiment:')
                             print(df_curr.index.levels)
@@ -288,7 +288,7 @@ def get_raw_data(i):
                             print(df_prev.index.levels)
                             print('[Info] as:')
         #                     df_curr.index = df_prev.index.copy() # TODO: increment repetition_id
-                            df_curr.index = pd.MultiIndex.from_tuples([(x[0],x[1],x[2],x[3],x[4],x[5],x[6]+1) for x in df_prev.index])
+                            df_curr.index = pd.MultiIndex.from_tuples([(x[0],x[1],x[2],x[3],x[4],x[5],x[6]+1,x[7]) for x in df_prev.index])
                             print(df_curr.index.levels)
                             print
                         else:
@@ -347,7 +347,7 @@ def get_raw_data(i):
         'total_seconds',
         '_ansatz_method',
         'vendor',
-        'molecule',
+        '_molecule',
     ]
 
     for record in df.to_dict(orient='records'):
@@ -382,7 +382,7 @@ def get_raw_data(i):
     df_m = merge_experimental_results(df)
 
     metrics_data = []
-    names_no_repetitions = df_m.index.names[:-1]
+    names_no_repetitions = [ n for n in df_m.index.names if n != 'repetition_id' ]
 
     for index, group in df_m.groupby(level=names_no_repetitions):
         runs = []

--- a/module/hackathon.20181006/module.py
+++ b/module/hackathon.20181006/module.py
@@ -232,7 +232,7 @@ def get_raw_data(i):
                 ]
                 
                 index = [
-                    'platform', 'team', 'minimizer_method', 'sample_number', 'max_iterations', 'point', 'repetition_id', 'molecule'
+                    'platform', 'team', 'minimizer_method', 'sample_number', 'max_iterations', 'point', 'repetition_id', 'molecule', 'ansatz_method'
                 ]
 
                 for datum in data:
@@ -251,7 +251,6 @@ def get_raw_data(i):
                     datum['vendor'] = vendor
                     for key in index:
                         datum['_' + key] = datum[key]
-                    datum['_ansatz_method'] = datum['ansatz_method']
                     datum['_ansatz_src'] = datum['ansatz_src']
                     datum['_minimizer_src'] = datum['minimizer_src']
 
@@ -288,7 +287,7 @@ def get_raw_data(i):
                             print(df_prev.index.levels)
                             print('[Info] as:')
         #                     df_curr.index = df_prev.index.copy() # TODO: increment repetition_id
-                            df_curr.index = pd.MultiIndex.from_tuples([(x[0],x[1],x[2],x[3],x[4],x[5],x[6]+1,x[7]) for x in df_prev.index])
+                            df_curr.index = pd.MultiIndex.from_tuples([(x[0],x[1],x[2],x[3],x[4],x[5],x[6]+1,x[7],x[8]) for x in df_prev.index])
                             print(df_curr.index.levels)
                             print
                         else:


### PR DESCRIPTION
Issue: https://github.com/ctuning/ck-quantum/issues/9
This PR adds filtering by molecule and ansatz to Time-To-Solution workflows.